### PR TITLE
Improve dashboard card layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "tailwindcss": "^4.1.7",
     "typescript": "~5.8.3",
     "vite": "^6.3.5",
-    "vue-tsc": "^2.2.8"
+    "vue-tsc": "^2.2.8",
+    "@types/node": "^22.0.0"
   }
 }

--- a/src/components/ServiceCard.vue
+++ b/src/components/ServiceCard.vue
@@ -1,29 +1,27 @@
 <template>
     <div @click="expanded = !expanded" class="cursor-pointer">
-        <div :class="['rounded-[20px] p-4 shadow-md backdrop-blur-lg flex flex-col h-[150px] transition-colors', backgroundClass]">
+        <div :class="['rounded-3xl p-6 shadow-lg shadow-black/5 backdrop-blur-sm bg-white/30 flex flex-col h-[160px] transition-colors', backgroundClass]">
             <div class="flex items-center justify-between">
                 <h4 class="font-semibold">{{ title }}</h4>
                 <ChevronDown :class="['w-5 h-5 transition-transform duration-300', expanded ? 'rotate-180' : '']"/>
             </div>
-            <div class="mt-2 flex items-center gap-2 text-xs">
-                <span class="px-2 py-0.5 rounded-full font-medium"
-                    :class="{'bg-green-100 text-green-700': status === 'Online',
-                             'bg-red-100 text-red-700': status === 'Offline',
-                             'bg-yellow-100 text-yellow-700': status === 'Maintenance'}">
-                    {{ status }}
-                </span>
+            <div class="mt-2 flex items-center gap-4 text-xs">
+                <div class="flex items-center gap-2">
+                    <span :class="['w-2.5 h-2.5 rounded-full', statusColor]"></span>
+                    <span class="text-sm font-medium text-gray-800">{{ status }}</span>
+                </div>
                 <span class="text-gray-600">Uptime: {{ uptime }}</span>
                 <span class="text-gray-600">Version: {{ version }}</span>
             </div>
-            <div class="flex justify-between mt-auto pt-4">
-                <button title="Restart service" class="p-2 rounded-md bg-white/20 backdrop-blur hover:bg-white/30 transition">
-                    <RefreshCw class="w-5 h-5 text-gray-800" />
+            <div class="flex justify-evenly items-center mt-auto pt-4">
+                <button title="Restart service" class="w-10 h-10 rounded-full bg-white/40 hover:bg-white/60 shadow-md transition-all flex items-center justify-center">
+                    <RefreshCw class="w-4 h-4 text-gray-700" />
                 </button>
-                <button title="View details" class="p-2 rounded-md bg-white/20 backdrop-blur hover:bg-white/30 transition">
-                    <Info class="w-5 h-5 text-gray-800" />
+                <button title="View details" class="w-10 h-10 rounded-full bg-white/40 hover:bg-white/60 shadow-md transition-all flex items-center justify-center">
+                    <Info class="w-4 h-4 text-gray-700" />
                 </button>
-                <button title="Configure service" class="p-2 rounded-md bg-white/20 backdrop-blur hover:bg-white/30 transition">
-                    <Settings class="w-5 h-5 text-gray-800" />
+                <button title="Configure service" class="w-10 h-10 rounded-full bg-white/40 hover:bg-white/60 shadow-md transition-all flex items-center justify-center">
+                    <Settings class="w-4 h-4 text-gray-700" />
                 </button>
             </div>
         </div>
@@ -80,6 +78,12 @@ const backgroundClass = computed(() => {
     if (status === 'Online') return 'bg-green-50'
     if (status === 'Offline') return 'bg-red-50'
     return 'bg-yellow-50'
+})
+
+const statusColor = computed(() => {
+    if (status === 'Online') return 'bg-green-500'
+    if (status === 'Offline') return 'bg-red-500'
+    return 'bg-yellow-400'
 })
 // State for expand/collapse and face index
 const expanded = ref(false)

--- a/src/components/ServiceCard.vue
+++ b/src/components/ServiceCard.vue
@@ -1,6 +1,6 @@
 <template>
     <div @click="expanded = !expanded" class="cursor-pointer">
-        <div class="rounded-[24px] p-6 bg-white/20 backdrop-blur-lg shadow-[0_8px_32px_rgba(0,0,0,0.1)]">
+        <div :class="['rounded-[20px] p-4 shadow-md backdrop-blur-lg flex flex-col h-[150px] transition-colors', backgroundClass]">
             <div class="flex items-center justify-between">
                 <h4 class="font-semibold">{{ title }}</h4>
                 <ChevronDown :class="['w-5 h-5 transition-transform duration-300', expanded ? 'rotate-180' : '']"/>
@@ -15,19 +15,18 @@
                 <span class="text-gray-600">Uptime: {{ uptime }}</span>
                 <span class="text-gray-600">Version: {{ version }}</span>
             </div>
+            <div class="flex justify-between mt-auto pt-4">
+                <button title="Restart service" class="p-2 rounded-md bg-white/20 backdrop-blur hover:bg-white/30 transition">
+                    <RefreshCw class="w-5 h-5 text-gray-800" />
+                </button>
+                <button title="View details" class="p-2 rounded-md bg-white/20 backdrop-blur hover:bg-white/30 transition">
+                    <Info class="w-5 h-5 text-gray-800" />
+                </button>
+                <button title="Configure service" class="p-2 rounded-md bg-white/20 backdrop-blur hover:bg-white/30 transition">
+                    <Settings class="w-5 h-5 text-gray-800" />
+                </button>
+            </div>
         </div>
-        <div class="flex justify-end gap-2 mt-4">
-            <button title="Restart service" class="p-2 rounded-md bg-white/20 backdrop-blur hover:bg-white/30 transition">
-                <RefreshCw class="w-5 h-5 text-gray-800" />
-            </button>
-            <button title="View details" class="p-2 rounded-md bg-white/20 backdrop-blur hover:bg-white/30 transition">
-                <Info class="w-5 h-5 text-gray-800" />
-            </button>
-            <button title="Configure service" class="p-2 rounded-md bg-white/20 backdrop-blur hover:bg-white/30 transition">
-                <Settings class="w-5 h-5 text-gray-800" />
-            </button>
-        </div>
-    </div>
     <Transition name="expand">
         <div v-if="expanded" class="mt-4">
             <Transition name="fade-slide" mode="out-in">
@@ -69,13 +68,19 @@
     </Transition>
 </template>
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { RefreshCw, Info, Settings, ChevronDown } from 'lucide-vue-next'
 import type {Service} from '../config/Service'
 
 const props = defineProps<Service>()
 // destructed props for easier access
-const {title, status, uptime, version} = props 
+const {title, status, uptime, version} = props
+
+const backgroundClass = computed(() => {
+    if (status === 'Online') return 'bg-green-50'
+    if (status === 'Offline') return 'bg-red-50'
+    return 'bg-yellow-50'
+})
 // State for expand/collapse and face index
 const expanded = ref(false)
 const currentFace = ref(0)

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -3,11 +3,17 @@
   <div class="h-full w-full bg-gradient-to-br from-white/40 to-blue-100 p-4">
     <!-- Header block -->
     <div
-    class="rounded-[20px] backdrop-blur bg-white/30 p-6 shadow max-w-xl mx-auto mt-4 mb-6 text-center"
+    class="max-w-3xl mx-auto rounded-3xl bg-white/40 backdrop-blur-sm p-6 md:p-10 shadow-lg shadow-black/5 text-center mt-4 mb-10"
     >
-    <h2 class="text-xl font-bold">AAS Dataspace for Everybody</h2>
-    <p class="text-sm">Tenant: Tenant 3</p>
-    <p class="text-sm">Owner: Fraunhofer IESE</p>
+    <h2 class="text-xl font-bold mb-2">AAS Dataspace for Everybody</h2>
+    <p class="text-sm flex justify-center items-center gap-2">
+      <Building class="w-4 h-4" />
+      <span>Tenant: Tenant 3</span>
+    </p>
+    <p class="text-sm flex justify-center items-center gap-2 mt-1">
+      <CircleUser class="w-4 h-4" />
+      <span>Owner: Fraunhofer IESE</span>
+    </p>
   </div>
 
   <!--
@@ -16,7 +22,7 @@
   -->
 
   <!-- Card grid -->
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4 mt-8 w-full">
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 mt-10 max-w-screen-xl mx-auto">
       <ServiceCard
         v-for="(service, i) in services"
         :key="i"
@@ -29,6 +35,7 @@
 //import { computed } from 'vue'
 import ServiceCard from "../components/ServiceCard.vue";
 import { services } from "../config/services.config";
+import { Building, CircleUser } from 'lucide-vue-next';
 //import { useKubernetes } from '../composables/useKubernetes'
 
 //const { services: liveServices, loading, error } = useKubernetes()

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -3,7 +3,7 @@
   <div class="h-full w-full bg-gradient-to-br from-white/40 to-blue-100 p-4">
     <!-- Header block -->
     <div
-    class="rounded-2xl backdrop-blur bg-white/30 p-6 shadow max-w-xl mx-auto mt-4 text-center"
+    class="rounded-[20px] backdrop-blur bg-white/30 p-6 shadow max-w-xl mx-auto mt-4 mb-6 text-center"
     >
     <h2 class="text-xl font-bold">AAS Dataspace for Everybody</h2>
     <p class="text-sm">Tenant: Tenant 3</p>
@@ -16,7 +16,7 @@
   -->
 
   <!-- Card grid -->
-    <div class="grid grid-cols-3 gap-6 mt-8 w-full">
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4 mt-8 w-full">
       <ServiceCard
         v-for="(service, i) in services"
         :key="i"

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -20,7 +20,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "types": ["node"]
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
## Summary
- update ServiceCard design with Apple-style rounded cards
- align action buttons at the bottom of each card
- make Dashboard card grid responsive and add spacing

## Testing
- `npm run build` *(fails: cannot find type definitions for node)*

------
https://chatgpt.com/codex/tasks/task_e_684ad4fa79688330971e2b2356969c96